### PR TITLE
fix: reset mode on generate

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -131,6 +131,7 @@ impl eframe::App for PathyApp {
                 // condition, thus not rendering the button.
                 if !processed.is_empty() && ui.button("Generate").clicked() {
                     *result = Some(Self::generate(processed));
+                    *mode = CursorMode::Default;
                 }
                 if *mode != CursorMode::Default && ui.button("Finish").clicked() {
                     *mode = CursorMode::Default;


### PR DESCRIPTION
This way, making changes to the path will bring back preprocessing. Now having a tool selected before actually editing the path will not prevent preprocessing.